### PR TITLE
Changed Alfred OSINT to Tookie-OSINT

### DIFF
--- a/database.json
+++ b/database.json
@@ -118,7 +118,7 @@
                 "📦 Pinterest Downloader": "https://github.com/limkokhole/pinterest-downloader"
             },
             "Other": {
-                "🔍🦜 Alfred OSINT": "https://github.com/Alfredredbird/alfred"
+                "🔍🦜 Tookie OSINT": "https://github.com/Alfredredbird/Tookie-osint"
             }
             
         },


### PR DESCRIPTION
Alfred OSINT rebranded to Tookie-OSINT. The old link takes you to Tookie-OSINT but updating the link helps stop confusion